### PR TITLE
Fix concurrent streaming, FlushSentinel flush, and TTFB measurement

### DIFF
--- a/examples/simple_agent.py
+++ b/examples/simple_agent.py
@@ -29,89 +29,90 @@ server = AgentServer()
 
 logger = logging.getLogger("simple_agent")
 
+
+# Turn latency tracker — collects per-component metrics and prints a summary
+class TurnTracker:
+    def __init__(self) -> None:
+        self._reset()
+
+    def _reset(self) -> None:
+        self.eou_ms: float | None = None
+        self.llm_ttft_ms: float | None = None
+        self.tts_ttfb_ms: float | None = None
+        self.tts_audio_s: float | None = None
+
+    def record(self, metrics: AgentMetrics) -> None:
+        if isinstance(metrics, EOUMetrics):
+            self.eou_ms = round(metrics.end_of_utterance_delay * 1000)
+
+        elif isinstance(metrics, (RealtimeModelMetrics, LLMMetrics)):
+            ttft = metrics.ttft
+            if ttft > 0:
+                self.llm_ttft_ms = round(ttft * 1000)
+
+        elif isinstance(metrics, TTSMetrics):
+            self.tts_ttfb_ms = round(metrics.ttfb * 1000)
+            self.tts_audio_s = round(metrics.audio_duration, 1)
+            self._print_summary()
+
+    def _print_summary(self) -> None:
+        parts = []
+        total = 0.0
+
+        if self.eou_ms is not None:
+            parts.append(f"EOU {self.eou_ms}ms")
+            total += self.eou_ms
+
+        if self.llm_ttft_ms is not None:
+            parts.append(f"LLM {self.llm_ttft_ms}ms")
+            total += self.llm_ttft_ms
+
+        if self.tts_ttfb_ms is not None:
+            parts.append(f"TTS {self.tts_ttfb_ms}ms")
+            total += self.tts_ttfb_ms
+
+        total_s = round(total / 1000, 2)
+        audio_info = f" | audio={self.tts_audio_s}s" if self.tts_audio_s else ""
+        summary = " + ".join(parts)
+
+        logger.info(f"--- Turn latency: {summary} = {total_s}s{audio_info} ---")
+        self._reset()
+
+
+turn_tracker = TurnTracker()
+
+
 @server.rtc_session()
 async def my_agent(ctx: agents.JobContext):
-    # Create Faseeh TTS instance
     session = AgentSession(
-        # stt=openai.STT(),  # Arabic STT
         llm=openai.realtime.RealtimeModel(modalities=['text']),
-        tts=faseeh.TTS(),  # Faseeh TTS for Arabic
+        tts=faseeh.TTS(),
         vad=silero.VAD.load(),
     )
+
+    @session.on("metrics_collected")
+    def _on_metrics_collected(event):
+        turn_tracker.record(event.metrics)
+        log_metrics(metrics=event.metrics)
 
     await session.start(
         room=ctx.room,
         agent=ArabicAssistant(),
     )
 
-    # Greet in Arabic
     await session.generate_reply(
         instructions="رحب بالمستخدم باللغة العربية وقدم المساعدة."
     )
-    @session.on("metrics_collected")
-    def _on_metrics_collected(event):
-        log_metrics(metrics=event.metrics)
 
 
 def log_metrics(metrics: AgentMetrics) -> None:
-    metadata: dict[str, str | float] = {}
-    if metrics.metadata:
-        metadata |= {
-            "model_name": metrics.metadata.model_name or "unknown",
-            "model_provider": metrics.metadata.model_provider or "unknown",
-        }
-
-    if isinstance(metrics, LLMMetrics):
-        logger.info(
-            "LLM metrics",
-            extra=metadata
-                  | {
-                      "ttft": round(metrics.ttft, 2),
-                      "prompt_tokens": metrics.prompt_tokens,
-                      "prompt_cached_tokens": metrics.prompt_cached_tokens,
-                      "completion_tokens": metrics.completion_tokens,
-                      "tokens_per_second": round(metrics.tokens_per_second, 2),
-                  },
-        )
-    elif isinstance(metrics, RealtimeModelMetrics):
-        logger.info(
-            "RealtimeModel metrics",
-            extra=metadata
-                  | {
-                      "ttft": round(metrics.ttft, 2),
-                      "input_tokens": metrics.input_tokens,
-                      "cached_input_tokens": metrics.input_token_details.cached_tokens,
-                      "output_tokens": metrics.output_tokens,
-                      "total_tokens": metrics.total_tokens,
-                      "tokens_per_second": round(metrics.tokens_per_second, 2),
-                  },
-        )
+    if isinstance(metrics, (RealtimeModelMetrics, LLMMetrics)):
+        ttft = metrics.ttft if isinstance(metrics, LLMMetrics) else metrics.ttft
+        logger.info(f"  LLM TTFT: {round(ttft * 1000)}ms")
     elif isinstance(metrics, TTSMetrics):
-        logger.info(
-            "TTS metrics",
-            extra=metadata
-                  | {
-                      "ttfb": metrics.ttfb,
-                      "audio_duration": round(metrics.audio_duration, 2),
-                  },
-        )
+        logger.info(f"  TTS TTFB: {round(metrics.ttfb * 1000)}ms | audio: {round(metrics.audio_duration, 1)}s")
     elif isinstance(metrics, EOUMetrics):
-        logger.info(
-            "EOU metrics",
-            extra=metadata
-                  | {
-                      "end_of_utterance_delay": round(metrics.end_of_utterance_delay, 2),
-                      "transcription_delay": round(metrics.transcription_delay, 2),
-                  },
-        )
-    elif isinstance(metrics, STTMetrics):
-        logger.info(
-            "STT metrics",
-            extra=metadata
-                  | {
-                      "audio_duration": round(metrics.audio_duration, 2),
-                  },
-        )
+        logger.info(f"  EOU: {round(metrics.end_of_utterance_delay * 1000)}ms")
 
 if __name__ == "__main__":
     agents.cli.run_app(server)

--- a/examples/test_concurrency_agent.py
+++ b/examples/test_concurrency_agent.py
@@ -1,0 +1,193 @@
+"""
+Faseeh TTS Concurrency & Streaming Test Agent
+
+Tests concurrent streaming, flush handling, and interruption resilience:
+1. FlushSentinel correctly flushes short buffers (short responses play audio)
+2. Concurrent _read_input/_send_chunks (interruptions don't crash)
+3. TTFB accuracy (measured before HTTP request, includes network round trip)
+
+Run a specific test by speaking its number:
+  "test one"   → 1-2 word response (FlushSentinel fix)
+  "test two"   → Short sentence (below soft threshold)
+  "test three" → Long response (concurrent streaming)
+  "test four"  → Very long response, interrupt it mid-speech
+  "test five"  → Rapid-fire: say it, interrupt, say it again
+
+Watch logs for:
+  ✅ TTS metrics with TTFB > 0ms
+  ❌ "no audio frames were pushed" = BUG STILL PRESENT
+"""
+
+import logging
+
+from dotenv import load_dotenv
+from livekit.agents.metrics import STTMetrics, EOUMetrics, TTSMetrics, RealtimeModelMetrics, LLMMetrics, AgentMetrics
+
+from livekit import agents
+from livekit.agents import AgentServer, AgentSession, Agent
+from livekit.plugins import silero, openai
+from livekit.plugins import faseeh
+
+load_dotenv(".env.local")
+
+# Force LLM to produce controlled output lengths via system instructions
+SYSTEM_PROMPT = """\
+You are a test assistant that responds ONLY in Arabic. Your job is to follow
+length instructions precisely.
+
+RULES:
+- ALWAYS respond in Arabic only.
+- When told to give a "short" answer: respond with EXACTLY 1-3 Arabic words. Nothing more.
+- When told to give a "medium" answer: respond with EXACTLY 1 Arabic sentence (8-15 words).
+- When told to give a "long" answer: respond with a long Arabic paragraph (50+ words). Keep going.
+- When told to give a "very long" answer: respond with multiple Arabic paragraphs (100+ words). Do not stop early.
+
+TEST COMMANDS (respond to these exactly):
+- "test one" → Reply with exactly 2 Arabic words. Example: "مرحبا بك"
+- "test two" → Reply with exactly one short Arabic sentence (8-12 words).
+- "test three" → Reply with a long Arabic paragraph about the desert (50+ words).
+- "test four" → Reply with a very long Arabic story about a traveler (100+ words). Keep going, do not stop.
+- "test five" → Reply with exactly 3 Arabic words.
+
+For any other input, reply with one medium Arabic sentence.
+"""
+
+server = AgentServer()
+logger = logging.getLogger("test_tts_fixes")
+logging.basicConfig(level=logging.INFO)
+
+# Enable debug logs from the Faseeh TTS plugin
+logging.getLogger("livekit.plugins.faseeh").setLevel(logging.DEBUG)
+
+tts_call_count = 0
+tts_total_ttfb = 0.0
+cancelled_count = 0
+
+
+class TestTurnTracker:
+    """Tracks per-turn latency and flags concurrency/flush issues."""
+
+    def __init__(self) -> None:
+        self._reset()
+
+    def _reset(self) -> None:
+        self.eou_ms: float | None = None
+        self.llm_ttft_ms: float | None = None
+        self.tts_ttfb_ms: float | None = None
+        self.tts_audio_s: float | None = None
+        self.cancelled: bool = False
+
+    def record(self, metrics: AgentMetrics) -> None:
+        global tts_call_count, tts_total_ttfb, cancelled_count
+
+        if isinstance(metrics, EOUMetrics):
+            self.eou_ms = round(metrics.end_of_utterance_delay * 1000)
+            logger.info(f"  EOU: {self.eou_ms}ms")
+
+        elif isinstance(metrics, (RealtimeModelMetrics, LLMMetrics)):
+            ttft = metrics.ttft
+            if ttft > 0:
+                self.llm_ttft_ms = round(ttft * 1000)
+                logger.info(f"  LLM TTFT: {self.llm_ttft_ms}ms")
+
+        elif isinstance(metrics, TTSMetrics):
+            tts_call_count += 1
+            ttfb_ms = round(metrics.ttfb * 1000)
+            tts_total_ttfb += metrics.ttfb
+            audio_dur = round(metrics.audio_duration, 2)
+
+            self.tts_ttfb_ms = ttfb_ms
+            self.tts_audio_s = audio_dur
+            self.cancelled = metrics.cancelled
+
+            # Concurrency fix validation
+            status = "✅" if ttfb_ms > 5 else "⚠️  SUSPICIOUS (near 0ms — _mark_started may be wrong)"
+            cancel_tag = " [CANCELLED — concurrency fix kept it clean]" if metrics.cancelled else ""
+            logger.info(
+                f"  TTS #{tts_call_count} {status} "
+                f"TTFB={ttfb_ms}ms | audio={audio_dur}s{cancel_tag}"
+            )
+
+            if metrics.cancelled:
+                cancelled_count += 1
+                logger.info(
+                    f"  ℹ️  Stream was interrupted/cancelled ({cancelled_count} total). "
+                    f"No crash = concurrency fix working."
+                )
+
+            self._print_summary()
+
+    def _print_summary(self) -> None:
+        parts = []
+        total = 0.0
+
+        if self.eou_ms is not None:
+            parts.append(f"EOU {self.eou_ms}ms")
+            total += self.eou_ms
+
+        if self.llm_ttft_ms is not None:
+            parts.append(f"LLM {self.llm_ttft_ms}ms")
+            total += self.llm_ttft_ms
+
+        if self.tts_ttfb_ms is not None:
+            parts.append(f"TTS {self.tts_ttfb_ms}ms")
+            total += self.tts_ttfb_ms
+
+        total_s = round(total / 1000, 2)
+        audio_info = f" | audio={self.tts_audio_s}s" if self.tts_audio_s else ""
+        cancel_info = " [CANCELLED]" if self.cancelled else ""
+        summary = " + ".join(parts)
+
+        logger.info(f"  --- Turn latency: {summary} = {total_s}s{audio_info}{cancel_info} ---")
+
+        # Running average
+        if tts_call_count > 0:
+            avg_ttfb = round((tts_total_ttfb / tts_call_count) * 1000)
+            logger.info(f"  --- Avg TTFB over {tts_call_count} calls: {avg_ttfb}ms | cancelled: {cancelled_count} ---")
+
+        self._reset()
+
+
+turn_tracker = TestTurnTracker()
+
+
+@server.rtc_session()
+async def test_agent(ctx: agents.JobContext):
+    session = AgentSession(
+        llm=openai.realtime.RealtimeModel(modalities=["text"]),
+        tts=faseeh.TTS(),
+        vad=silero.VAD.load(),
+    )
+
+    @session.on("metrics_collected")
+    def _on_metrics(event):
+        turn_tracker.record(event.metrics)
+
+    await session.start(
+        room=ctx.room,
+        agent=Agent(instructions=SYSTEM_PROMPT),
+    )
+
+    # Auto-trigger test 1 on connect (short response = FlushSentinel test)
+    logger.info("=" * 60)
+    logger.info("TEST AGENT STARTED — speak a test command")
+    logger.info("  'test one'   → 2 words (FlushSentinel fix)")
+    logger.info("  'test two'   → short sentence")
+    logger.info("  'test three' → long paragraph (streaming)")
+    logger.info("  'test four'  → very long, INTERRUPT it (concurrency fix)")
+    logger.info("  'test five'  → 3 words, rapid interrupt test")
+    logger.info("")
+    logger.info("WHAT TO VERIFY:")
+    logger.info("  ✅ All tests produce TTS TTFB > 5ms")
+    logger.info("  ✅ test one/five: audio plays (FlushSentinel flushes short buffers)")
+    logger.info("  ✅ test four interrupted: no crash, 'CANCELLED' in logs")
+    logger.info("  ❌ 'no audio frames were pushed' = BUG STILL PRESENT")
+    logger.info("=" * 60)
+
+    await session.generate_reply(
+        instructions="قل فقط: مرحبا"
+    )
+
+
+if __name__ == "__main__":
+    agents.cli.run_app(server)

--- a/livekit/plugins/faseeh/tts.py
+++ b/livekit/plugins/faseeh/tts.py
@@ -48,9 +48,9 @@ HARD_DELIMITERS = {'.', '!', '؟', '\n'}  # Sentence endings and line breaks
 SOFT_DELIMITERS = {',', '،', ';', '؛', ':', '—', '–'}  # Phrase boundaries
 
 # Word count thresholds for chunking
-HARD_WORD_THRESHOLD = 16   # Check for hard delimiters after 8 words
-SOFT_WORD_THRESHOLD = 32  # Check for soft delimiters after 12 words
-SAFETY_WORD_THRESHOLD = 48  # Force split after 20 words even without punctuation
+HARD_WORD_THRESHOLD = 16
+SOFT_WORD_THRESHOLD = 32
+SAFETY_WORD_THRESHOLD = 48
 
 
 @dataclass
@@ -74,6 +74,9 @@ class TTS(tts.TTS):
         model: TTSModels | str = "faseeh-v1-preview",
         stability: float = 0.5,
         speed: float = 1.0,
+        hard_word_threshold: int = HARD_WORD_THRESHOLD,
+        soft_word_threshold: int = SOFT_WORD_THRESHOLD,
+        safety_word_threshold: int = SAFETY_WORD_THRESHOLD,
         api_key: NotGivenOr[str] = NOT_GIVEN,
         base_url: NotGivenOr[str] = NOT_GIVEN,
         http_session: aiohttp.ClientSession | None = None,
@@ -117,6 +120,9 @@ class TTS(tts.TTS):
             speed=speed,
             api_key=faseeh_api_key,
             base_url=base_url if is_given(base_url) else API_BASE_URL,
+            hard_word_threshold=hard_word_threshold,
+            soft_word_threshold=soft_word_threshold,
+            safety_word_threshold=safety_word_threshold,
         )
         self._session = http_session
         self._streams = weakref.WeakSet[SynthesizeStream]()
@@ -344,6 +350,7 @@ class SynthesizeStream(tts.SynthesizeStream):
         }
 
         try:
+            self._mark_started()
             async with self._tts._ensure_session().post(
                 url,
                 headers=headers,
@@ -396,7 +403,6 @@ class SynthesizeStream(tts.SynthesizeStream):
                 async for chunk, _ in resp.content.iter_chunks():
                     if chunk:
                         output_emitter.push(chunk)
-                        self._mark_started()
 
         except asyncio.TimeoutError as e:
             raise APITimeoutError() from e
@@ -424,11 +430,16 @@ class SynthesizeStream(tts.SynthesizeStream):
         )
         output_emitter.start_segment(segment_id=request_id)
 
-        try:
+        chunk_queue: asyncio.Queue[str | None] = asyncio.Queue()
+
+        async def _read_input() -> None:
             buffer = ""
 
             async for data in self._input_ch:
                 if isinstance(data, self._FlushSentinel):
+                    if buffer.strip():
+                        await chunk_queue.put(buffer.strip())
+                        buffer = ""
                     continue
 
                 buffer += data
@@ -437,28 +448,34 @@ class SynthesizeStream(tts.SynthesizeStream):
 
                 chunk_to_send = None
 
-                # After 8 words: try hard delimiters (sentence boundaries)
-                if word_count >= HARD_WORD_THRESHOLD:
+                if word_count >= self._tts._opts.hard_word_threshold:
                     chunk_to_send, buffer = self._split_on_delimiters(buffer, HARD_DELIMITERS)
 
-                # After 12 words: try soft delimiters (phrase boundaries)
-                if not chunk_to_send and word_count >= SOFT_WORD_THRESHOLD:
+                if not chunk_to_send and word_count >= self._tts._opts.soft_word_threshold:
                     chunk_to_send, buffer = self._split_on_delimiters(buffer, SOFT_DELIMITERS)
 
-                # After 20 words: force split at word boundary (safety valve)
-                if not chunk_to_send and word_count >= SAFETY_WORD_THRESHOLD:
-                    # Keep last 3 words in buffer for context continuity
+                if not chunk_to_send and word_count >= self._tts._opts.safety_word_threshold:
                     chunk_to_send = ' '.join(words[:-3])
                     buffer = ' '.join(words[-3:])
 
-                # Send chunk if we have one
                 if chunk_to_send:
-                    await self._stream_chunk(chunk_to_send, output_emitter)
+                    await chunk_queue.put(chunk_to_send)
 
-            # Send any remaining text in buffer
+            # Send any remaining text
             if buffer.strip():
-                await self._stream_chunk(buffer.strip(), output_emitter)
+                await chunk_queue.put(buffer.strip())
 
+            await chunk_queue.put(None)  # signal done
+
+        async def _send_chunks() -> None:
+            while True:
+                chunk = await chunk_queue.get()
+                if chunk is None:
+                    break
+                await self._stream_chunk(chunk, output_emitter)
+
+        try:
+            await asyncio.gather(_read_input(), _send_chunks())
             output_emitter.flush()
 
         except (APIError, APIStatusError, APITimeoutError, APIConnectionError):
@@ -478,3 +495,6 @@ class _TTSOptions:
     stability: float
     speed: float
     base_url: str
+    hard_word_threshold: int
+    soft_word_threshold: int
+    safety_word_threshold: int

--- a/livekit/plugins/faseeh/version.py
+++ b/livekit/plugins/faseeh/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.1.4"
+__version__ = "0.1.5"


### PR DESCRIPTION
## Summary
                                                                                                                         
  - **Concurrent streaming** (Fixes #3): `SynthesizeStream._run()` now uses a producer-consumer pattern — `_read_input()` chunks LLM tokens into an `asyncio.Queue` while `_send_chunks()` makes HTTP POST calls concurrently via `asyncio.gather()`. HTTP calls no longer block input reading, so interruptions don't cause "no audio frames were
  pushed" errors.
  - **FlushSentinel flush** (Fixes #3): FlushSentinel now flushes the buffer immediately instead of being ignored, fixing silent output for short (< threshold) LLM responses.
  - **TTFB measurement** (Fixes #1): `_mark_started()` moved before the HTTP POST to capture full network round trip in TTFB metrics.
  - **Configurable thresholds & removed misleading comments** (Fixes #2): Word count thresholds are now configurable via `TTS()` constructor and the incorrect inline comments have been removed.
  - **Turn latency tracking**: `simple_agent.py` now prints combined `EOU + LLM + TTS = total` per turn.
  - **Test agent**: New `test_concurrency_agent.py` for regression testing concurrency, flush, and interruption handling.

  ## Test plan

  - [x] Run `test_concurrency_agent.py` — "test one" (2 words) produces audio (FlushSentinel fix)
  - [x] "test four" interrupted mid-speech — no crash, clean cancellation (concurrency fix)
  - [x] TTS TTFB reflects network latency (~300-500ms), not near-zero (TTFB fix)
  - [x] Long responses ("test three") stream audio while LLM is still producing tokens
  - [x] `simple_agent.py` prints turn latency summary: `EOU Xms + LLM Xms + TTS Xms = Xs`